### PR TITLE
remove "what_to_say" from gcs name

### DIFF
--- a/html-demo/aws/aws_s3.tf
+++ b/html-demo/aws/aws_s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "website_bucket" {
-  bucket = "hello-vang-${random_string.random.result}-${replace(lower(var.what_to_say)," ","-")}"
+  bucket = "codepipes-html-demo-${random_string.random.result}"
   acl    = "public-read"
 
   force_destroy = true

--- a/html-demo/gcp/gcp_storage.tf
+++ b/html-demo/gcp/gcp_storage.tf
@@ -1,6 +1,6 @@
 resource "google_storage_bucket" "website_bucket" {
   provider = google-beta
-  name = "hello-vang-${random_string.random.result}-${replace(lower(var.what_to_say)," ","-")}"
+  name = "codepipes-html-demo-${random_string.random.result}"
   force_destroy = true
   project = var.GOOGLE_PROJECT
 


### PR DESCRIPTION
It just breaks in a lot of ways. If user includes special characters like `!`
once epic failure is, if I set what_to_say to "Hi Google" it fails because
bucket name cannot have the word google in it or g00gle

This PR fixes it by removing `what_to_say` value from the bucket name.
I believe since we append a random string already to name, it should be all-right doing this.