### PR TITLE
VAN-2028 Updated TF code for upgraded GCP TF Prov

### DIFF
--- a/voting/infra/gcp/gke/gke/main.tf
+++ b/voting/infra/gcp/gke/gke/main.tf
@@ -81,15 +81,6 @@ resource "google_container_cluster" "this" {
     }
   }
 
-  master_auth {
-    username = var.basic_auth_username
-    password = var.basic_auth_password
-
-    client_certificate_config {
-      issue_client_certificate = var.issue_client_certificate
-    }
-  }
-
   # dynamic "master_authorized_networks_config" {
   #   for_each = local.master_authorized_networks_config
   #   content {
@@ -144,6 +135,6 @@ resource "google_container_cluster" "this" {
   }
 
   workload_identity_config {
-    identity_namespace = "${var.project}.svc.id.goog"
+    workload_pool = "${var.project}.svc.id.goog"
   }
 }

--- a/voting/infra/gcp/gke/gke/node_pool.tf
+++ b/voting/infra/gcp/gke/gke/node_pool.tf
@@ -70,7 +70,7 @@ resource "google_container_node_pool" "this" {
     }
 
     workload_metadata_config {
-      node_metadata = "GKE_METADATA_SERVER"
+      mode = "GKE_METADATA"
     }
   }
 

--- a/voting/infra/gcp/gke/gke/outputs.tf
+++ b/voting/infra/gcp/gke/gke/outputs.tf
@@ -10,7 +10,7 @@ output "endpoint" {
 
 output "instance_group_urls" {
   description = "List of instance group URLs which have been assigned to the cluster."
-  value       = google_container_cluster.this.instance_group_urls
+  value       = google_container_cluster.this.node_pool[0].instance_group_urls
 }
 
 output "ca_certificate" {

--- a/voting/infra/gcp/gke/gke/variables.tf
+++ b/voting/infra/gcp/gke/gke/variables.tf
@@ -75,24 +75,6 @@ variable "maintenance_start_time" {
   default     = "05:00"
 }
 
-variable "basic_auth_username" {
-  type        = string
-  description = "The username to be used with Basic Authentication. An empty value will disable Basic Authentication, which is the recommended configuration."
-  default     = ""
-}
-
-variable "basic_auth_password" {
-  type        = string
-  description = "The password to be used with Basic Authentication."
-  default     = ""
-}
-
-variable "issue_client_certificate" {
-  type        = bool
-  description = "Issues a client certificate to authenticate to the cluster endpoint. To maximize the security of your cluster, leave this option disabled. Client certificates don't automatically rotate and aren't easily revocable. WARNING: changing this after cluster creation is destructive!"
-  default     = false
-}
-
 variable "master_authorized_networks" {
   type        = list(object({ cidr_block = string, display_name = string }))
   description = <<EOF

--- a/voting/infra/gcp/gke/gke/versions.tf
+++ b/voting/infra/gcp/gke/gke/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = ">= 0.12"
   required_providers {
-    google = ">= 3.22, < 4.0"
+    google = ">= 3.22, < 5.0"
   }
 }


### PR DESCRIPTION
Updated GKE with provider with changes
- Changed Identity_Workspace to Workload_Pool
- Change instance_group_urls to managed_instance_group_urls and node_metadata to node
- Updated Instance Group URLs
- Changed GKE_METADATA_SERVER to GKE_METADATA
- Updated Voting app for GCP Provider changes
- Removed unrequired variables in GKE Voting App
