### PR TITLE
Fix html-demo google_storage_bucket resource

### DIFF
--- a/html-demo/gcp/gcp_storage.tf
+++ b/html-demo/gcp/gcp_storage.tf
@@ -1,5 +1,6 @@
 resource "google_storage_bucket" "website_bucket" {
   provider = google-beta
+  location = "US"
   name = "codepipes-html-demo-${random_string.random.result}"
   force_destroy = true
   project = var.GOOGLE_PROJECT


### PR DESCRIPTION
New version of TF provider now requires the "location" parameter.
