### PR TITLE
Fix AWS Output URL for Cat Demo

### DIFF
--- a/html-demo/aws/output.tf
+++ b/html-demo/aws/output.tf
@@ -1,3 +1,3 @@
 output "aws_url" {
-  value = aws_s3_bucket.website_bucket.website_endpoint
+  value = "http://${aws_s3_bucket.website_bucket.website_endpoint}/index.html"
 }


### PR DESCRIPTION
The Terraform output variable for the AWS URL in the Cat Demo
wasn't formatted as a proper HTTP endpoint.
