### PR TITLE
VAN-2507 Use more flexible pgsql version

### DIFF
--- a/voting/infra/aws/eks/db.tf
+++ b/voting/infra/aws/eks/db.tf
@@ -19,7 +19,7 @@ resource "aws_db_instance" "default" {
   allocated_storage    = 10
   #Type, version of DB and Instance Class to use
   engine               = "postgres"
-  engine_version       = "11.11"
+  engine_version       = "11"
   instance_class       = "db.t3.micro"
   #Credentials
   name                 = "postgres"
@@ -27,6 +27,7 @@ resource "aws_db_instance" "default" {
   password             = "postgres"
   #Setting this true so that there will be no problem while destroying the Infrastructure as it won't create snapshot
   skip_final_snapshot  = true
+  auto_minor_version_upgrade = true
 }
 
 resource "aws_security_group" "dbsg" {


### PR DESCRIPTION
Previouslyi the Voting TF code pinned the pgsql version to
v11.11.  This version is no longer available on AWS RDS. This pins to
v11.x and also the version to float as AWS upgrades.
