### PR TITLE
VAN-2929 Add TF scripts for resource creation

### DIFF
--- a/tools/cust_acct_setup/aws/README.md
+++ b/tools/cust_acct_setup/aws/README.md
@@ -1,0 +1,58 @@
+## To create Code Pipes resources in an AWS account
+
+Prerequisites:
+- AWS account has been created
+- AWS authentication setup locally using an account that has necessary permissions on the account. Typically you would set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY or use a local credential profile.
+
+Execution:
+1. Run terraform init
+```
+$ terraform init
+Initializing modules...
+- cp_artifact_bucket in modules/s3
+- cp_compliance_bucket in modules/s3
+
+Initializing the backend...
+
+Initializing provider plugins...
+- Finding hashicorp/aws versions matching "~> 4.0"...
+- Installing hashicorp/aws v4.40.0...
+- Installed hashicorp/aws v4.40.0 (signed by HashiCorp)
+
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+<snip>
+```
+
+2. Create terraform.tfvars file
+```
+$ cp terraform.tfvars.sample terraform.tfvars
+
+# use your editor of choice to adjust the values as appropriate
+```
+You can choose to use an IAM user (i.e. secret/access) for the Code Pipes credential or Role ARN. See terraform.tfvars.sample for a description
+of how to set the variables for each case.
+
+3. Run terraform apply
+```
+$ terraform apply
+
+Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
+  + create
+  <snip>
+Do you want to perform these actions?
+  Terraform will perform the actions described above.
+  Only 'yes' will be accepted to approve.
+
+  Enter a value: yes
+```
+
+4. Retrieve secret access key
+
+```
+$ cat terraform.tfstate|jq -r '.outputs["codepipes_secret_key"].value'
+
+# Note: this requires that 'jq' is installed in the local environment
+```

--- a/tools/cust_acct_setup/aws/main.tf
+++ b/tools/cust_acct_setup/aws/main.tf
@@ -1,0 +1,38 @@
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+}
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_user" "cp_user" {
+  count = var.create_iamuser ? 1 : 0
+  name  = var.username
+}
+
+resource "aws_iam_access_key" "cp_user_access" {
+  count = var.create_iamuser ? 1 : 0
+  user  = aws_iam_user.cp_user[0].name
+}
+
+resource "aws_iam_role" "cp_rolearn" {
+  count = var.create_rolearn ? 1 : 0
+  name  = var.rolename
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          AWS = "arn:aws:iam::${var.codepipes_aws_account}:${var.codepipes_aws_account_user}"
+        }
+        Condition = {
+          "StringEquals" : {
+            "sts:ExternalId" : "${var.codepipes_org_id}"
+          }
+        }
+      },
+    ]
+  })
+}

--- a/tools/cust_acct_setup/aws/modules/s3/main.tf
+++ b/tools/cust_acct_setup/aws/modules/s3/main.tf
@@ -1,0 +1,91 @@
+resource "aws_s3_bucket" "secure_bucket" {
+  bucket = var.bucket_name
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "secure_bucket_acl" {
+  bucket = aws_s3_bucket.secure_bucket.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_versioning" "secure_bucket_versioning" {
+  bucket = aws_s3_bucket.secure_bucket.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "secure_bucket_encryption" {
+  bucket = aws_s3_bucket.secure_bucket.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "single_policy" {
+  count  = var.add_logging_policy ? 0 : 1
+  bucket = aws_s3_bucket.secure_bucket.id
+  policy = data.aws_iam_policy_document.ssl_only.json
+}
+
+resource "aws_s3_bucket_policy" "with_logging_policy" {
+  count  = var.add_logging_policy ? 1 : 0
+  bucket = aws_s3_bucket.secure_bucket.id
+  policy = data.aws_iam_policy_document.merged_policies.json
+}
+
+data "aws_iam_policy_document" "merged_policies" {
+  source_policy_documents = [
+    data.aws_iam_policy_document.ssl_only.json,
+    data.aws_iam_policy_document.logging_access.json
+  ]
+}
+
+data "aws_iam_policy_document" "logging_access" {
+  statement {
+    sid = "s3_server_access_logs_policy"
+    principals {
+      type        = "Service"
+      identifiers = ["logging.s3.amazonaws.com"]
+    }
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectAcl"
+    ]
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+    effect = "Allow"
+    resources = [
+      "${aws_s3_bucket.secure_bucket.arn}/*",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "ssl_only" {
+  statement {
+    sid = "s3_bucket_ssl_requests_only"
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+    actions = [
+      "s3:*",
+    ]
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+    effect = "Deny"
+    resources = [
+      aws_s3_bucket.secure_bucket.arn,
+      "${aws_s3_bucket.secure_bucket.arn}/*",
+    ]
+  }
+}

--- a/tools/cust_acct_setup/aws/modules/s3/outputs.tf
+++ b/tools/cust_acct_setup/aws/modules/s3/outputs.tf
@@ -1,0 +1,3 @@
+output "secure_bucket" {
+    value = aws_s3_bucket.secure_bucket
+}

--- a/tools/cust_acct_setup/aws/modules/s3/variables.tf
+++ b/tools/cust_acct_setup/aws/modules/s3/variables.tf
@@ -1,0 +1,9 @@
+variable "bucket_name" {
+  description = "The name of S3 bucket to create"
+  type        = string
+}
+
+variable "add_logging_policy" {
+    description = "Whether to add the logging policy to the bucket"
+    type = bool
+}

--- a/tools/cust_acct_setup/aws/outputs.tf
+++ b/tools/cust_acct_setup/aws/outputs.tf
@@ -1,0 +1,38 @@
+output "codepipes_user_arn" {
+  value = var.create_iamuser ? aws_iam_user.cp_user[0].arn : null
+}
+
+output "codepipes_access_key" {
+  value = var.create_iamuser ? aws_iam_access_key.cp_user_access[0].id : null
+}
+
+output "codepipes_secret_key" {
+  value     = var.create_iamuser ? aws_iam_access_key.cp_user_access[0].secret : null
+  sensitive = true
+}
+
+output "codepipes_role_arn" {
+  value = var.create_rolearn ? aws_iam_role.cp_rolearn[0].arn : null
+}
+
+output "codepipes_region" {
+  value = var.region
+}
+
+output "codepipes_artifact_bucket" {
+  value = module.cp_artifact_bucket.secure_bucket.arn
+}
+
+output "codepipes_code_build_topic" {
+  # SNS topic ARN
+  value = aws_sns_topic.cp-codebuild-topic.arn
+}
+
+output "codepipes_code_build_listener" {
+  # SQS queue URL
+  value = aws_sqs_queue.cp-sqs-queue.id
+}
+
+output "codepipes_kms_key" {
+  value = aws_kms_key.cp_pipeline_key.arn
+}

--- a/tools/cust_acct_setup/aws/pipeline.tf
+++ b/tools/cust_acct_setup/aws/pipeline.tf
@@ -1,0 +1,177 @@
+resource "aws_iam_policy" "cp_policy" {
+  name        = "CodePipesPipelineRole"
+  path        = "/"
+  description = "Policy with permissions required to use Code Pipes"
+
+  # Terraform's "jsonencode" function converts a
+  # Terraform expression result to valid JSON syntax.
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:DeleteObjectVersion",
+          "s3:DeleteObject",
+          "s3:PutReplicationConfiguration"
+        ],
+        "Resource" : "arn:aws:s3:::*/*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "s3:ListBucketVersions",
+          "s3:CreateBucket",
+          "s3:ListBucket",
+          "s3:DeleteBucket",
+          "s3:GetBucketPolicy",
+          "s3:PutBucketPolicy",
+          "s3:PutEncryptionConfiguration",
+          "s3:PutBucketVersioning",
+          "s3:CreateReplicationRole",
+          "s3:PutBucketLogging",
+          "s3:PutBucketReplication",
+        ],
+        "Resource" : "arn:aws:s3:::*"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "codebuild:BatchGetBuilds",
+          "codebuild:BatchGetProjects",
+          "codebuild:CreateProject",
+          "codebuild:DeleteProject",
+          "codebuild:ListBuildBatches",
+          "codebuild:ListBuilds",
+          "codebuild:ListBuildsForProject",
+          "codebuild:ListProjects",
+          "codebuild:RetryBuild",
+          "codebuild:StartBuild",
+          "codebuild:StopBuild",
+          "codebuild:UpdateProject",
+          "events:PutRule",
+          "events:PutTargets",
+          "iam:CreatePolicy",
+          "iam:CreateRole",
+          "iam:GetPolicy",
+          "iam:GetRole",
+          "iam:ListAttachedRolePolicies",
+          "iam:ListInstanceProfilesForRole",
+          "iam:ListPolicyVersions",
+          "iam:ListEntitiesForPolicy",
+          "iam:GetPolicyVersion",
+          "iam:ListRolePolicies",
+          "iam:PassRole",
+          "kms:CreateKey",
+          "kms:CreateAlias",
+          "kms:DescribeKey",
+          "kms:GetKeyPolicy",
+          "kms:PutKeyPolicy",
+          "kms:TagResource",
+          "iam:DeletePolicy",
+          "iam:DeleteRole",
+          "iam:AttachRolePolicy",
+          "iam:DetachRolePolicy",
+          "secretsmanager:CreateSecret",
+          "secretsmanager:DeleteSecret",
+          "secretsmanager:DescribeSecret",
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:ListSecretVersionIds",
+          "secretsmanager:ListSecrets",
+          "secretsmanager:PutSecretValue",
+          "secretsmanager:UpdateSecret",
+          "sns:ConfirmSubscription",
+          "sns:CreateTopic",
+          "sns:DeletePlatformApplication",
+          "sns:DeleteTopic",
+          "sns:GetSubscriptionAttributes",
+          "sns:GetTopicAttributes",
+          "sns:ListSubscriptions",
+          "sns:ListSubscriptionsByTopic",
+          "sns:ListTopics",
+          "sns:Publish",
+          "sns:SetSubscriptionAttributes",
+          "sns:SetTopicAttributes",
+          "sns:Subscribe",
+          "sns:Unsubscribe",
+          "sqs:ChangeMessageVisibility",
+          "sqs:CreateQueue",
+          "sqs:DeleteMessage",
+          "sqs:DeleteQueue",
+          "sqs:GetQueueAttributes",
+          "sqs:GetQueueUrl",
+          "sqs:ListQueueTags",
+          "sqs:ListQueues",
+          "sqs:PurgeQueue",
+          "sqs:ReceiveMessage",
+          "sqs:SendMessage",
+          "sqs:SetQueueAttributes"
+        ],
+        "Resource" : "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_user_policy_attachment" "cp-attach-user" {
+  count      = var.create_iamuser ? 1 : 0
+  user       = aws_iam_user.cp_user[0].name
+  policy_arn = aws_iam_policy.cp_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "cp-attach-role" {
+  count      = var.create_rolearn ? 1 : 0
+  role       = aws_iam_role.cp_rolearn[0].name
+  policy_arn = aws_iam_policy.cp_policy.arn
+}
+
+resource "aws_iam_policy" "cp-codebuild-policy" {
+  name = "cldcvr-codebuild-policy"
+  path = "/"
+
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "secretsmanager:GetRandomPassword",
+          "secretsmanager:GetResourcePolicy",
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret",
+          "secretsmanager:ListSecretVersionIds",
+          "s3:*",
+          "sts:*",
+          "logs:*"
+        ],
+        "Resource" : "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "cp-codebuild-role" {
+  name = "cldcvr-codebuild-role"
+
+  assume_role_policy = <<POLICY
+{
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {
+                    "Service": "codebuild.amazonaws.com"
+                },
+                "Action": "sts:AssumeRole"
+            }
+        ]
+    }
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "cp-attach-codebuild" {
+  role       = aws_iam_role.cp-codebuild-role.name
+  policy_arn = aws_iam_policy.cp-codebuild-policy.arn
+}

--- a/tools/cust_acct_setup/aws/provider.tf
+++ b/tools/cust_acct_setup/aws/provider.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "aws" {
+    region = var.region
+}

--- a/tools/cust_acct_setup/aws/pubsub.tf
+++ b/tools/cust_acct_setup/aws/pubsub.tf
@@ -1,0 +1,118 @@
+resource "aws_kms_key" "cp_pipeline_key" {
+  tags = {
+    CreatedBy = var.key_name
+  }
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Sid" : "Enable IAM User Permissions",
+        "Effect" : "Allow",
+        "Action" : "kms:*",
+        "Resource" : "*",
+        "Principal" : {
+          "AWS" : "arn:aws:iam::${local.account_id}:root"
+        }
+      },
+      {
+        "Sid" : "Enable CloudWatch Permissions",
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "events.amazonaws.com"
+        },
+        "Action" : [
+          "kms:GenerateDataKey*",
+          "kms:Decrypt"
+        ],
+        "Resource" : "*"
+      }
+    ]
+  })
+}
+
+resource "aws_kms_alias" "cp_pipeline_key_alias" {
+  name          = join("/", ["alias", var.key_name])
+  target_key_id = aws_kms_key.cp_pipeline_key.key_id
+}
+
+resource "aws_sns_topic" "cp-codebuild-topic" {
+  name              = var.code_build_topic_name
+  kms_master_key_id = aws_kms_key.cp_pipeline_key.key_id
+}
+
+resource "aws_sns_topic_policy" "cp-codebuild-topic-policy" {
+  arn = aws_sns_topic.cp-codebuild-topic.arn
+  policy = jsonencode({
+    "Version" : "2008-10-17",
+    "Statement" : [
+      {
+        "Sid" : "Allow_Publish_Events",
+        "Effect" : "Allow",
+        "Action" : "sns:Publish",
+        "Principal" : {
+          "Service" : "events.amazonaws.com"
+        }
+        "Resource" : aws_sns_topic.cp-codebuild-topic.arn
+      },
+    ]
+  })
+}
+
+resource "aws_sqs_queue" "cp-sqs-queue" {
+  name                       = var.code_build_queue_name
+  message_retention_seconds  = var.sqs_queue_retention_period
+  receive_wait_time_seconds  = var.sqs_queue_receive_wait_time
+  visibility_timeout_seconds = 120
+  sqs_managed_sse_enabled    = true
+}
+
+resource "aws_sqs_queue_policy" "cp-sqs-queue-policy" {
+  queue_url = aws_sqs_queue.cp-sqs-queue.id
+
+  policy = jsonencode({
+    "Version" : "2008-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "sns.amazonaws.com"
+        },
+        "Action" : "sqs:SendMessage",
+        "Resource" : "${aws_sqs_queue.cp-sqs-queue.arn}",
+        "Condition" : {
+          "ArnEquals" : {
+            "aws:SourceArn" : "${aws_sns_topic.cp-codebuild-topic.arn}"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_sns_topic_subscription" "cp-sns-sqs-subscription" {
+  topic_arn = aws_sns_topic.cp-codebuild-topic.arn
+  protocol  = "sqs"
+  endpoint  = aws_sqs_queue.cp-sqs-queue.arn
+}
+
+resource "aws_cloudwatch_event_rule" "cp-eventbridge-rule" {
+  name        = "codepipes-code-build-state-change"
+  description = "CodeBuild state-change events for CodePipes"
+
+  event_pattern = <<EOF
+{
+  "detail": {
+    "build-status": ["IN_PROGRESS", "SUCCEEDED", "FAILED", "STOPPED"]
+  },
+  "detail-type": [
+    "CodeBuild Build State Change"
+  ],
+  "source": ["aws.codebuild"]
+}
+EOF
+}
+
+resource "aws_cloudwatch_event_target" "cp-eventbridge-target" {
+  rule = aws_cloudwatch_event_rule.cp-eventbridge-rule.name
+  arn  = aws_sns_topic.cp-codebuild-topic.arn
+}

--- a/tools/cust_acct_setup/aws/storage.tf
+++ b/tools/cust_acct_setup/aws/storage.tf
@@ -1,0 +1,110 @@
+module "cp_artifact_bucket" {
+  source = "./modules/s3"
+
+  bucket_name        = join("-", [var.bucket_name_prefix, "pipeline-artifacts", var.region, var.account_id])
+  add_logging_policy = false
+}
+
+module "cp_compliance_bucket" {
+  source = "./modules/s3"
+
+  bucket_name        = join("-", [var.bucket_name_prefix, "compliance", var.region, var.account_id])
+  add_logging_policy = true
+}
+
+# setup access logging
+resource "aws_s3_bucket_logging" "cp_bucket_logging_artifact" {
+  bucket = module.cp_artifact_bucket.secure_bucket.id
+
+  target_bucket = module.cp_compliance_bucket.secure_bucket.id
+  target_prefix = "access_log/"
+}
+resource "aws_iam_role" "replication" {
+  name = join("-", [var.bucket_name_prefix, "replication-role"])
+
+  assume_role_policy = <<POLICY
+{
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {
+                    "Service": "s3.amazonaws.com"
+                },
+                "Action": "sts:AssumeRole"
+            }
+        ]
+    }
+POLICY
+}
+
+resource "aws_iam_policy" "replication" {
+  name   = join("-", [var.bucket_name_prefix, "replication-policy"])
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "EnableSrcBucketAccess",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetReplicationConfiguration",
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::*"
+            ]
+        },
+        {
+            "Sid": "EnableSrcObjectsAccess",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObjectVersion",
+                "s3:GetObjectVersionAcl",
+                "s3:GetObjectVersionTagging"
+            ],
+            "Resource": [
+                "arn:aws:s3:::*/*"
+            ]
+        },
+        {
+            "Sid": "EnableDestAccess",
+            "Effect": "Allow",
+            "Action": [
+                "s3:ReplicateObject",
+                "s3:ReplicateDelete",
+                "s3:ReplicateTags"
+            ],
+            "Resource": "${module.cp_compliance_bucket.secure_bucket.arn}/*"
+        }   
+    ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "replication" {
+  role       = aws_iam_role.replication.name
+  policy_arn = aws_iam_policy.replication.arn
+}
+
+
+resource "aws_s3_bucket_replication_configuration" "cp_artifact_bucket_replication" {
+  role   = aws_iam_role.replication.arn
+  bucket = module.cp_artifact_bucket.secure_bucket.id
+  depends_on = [module.cp_artifact_bucket.secure_bucket_versioning, module.cp_compliance_bucket.secure_bucket_versioning]
+
+  rule {
+    filter {
+      prefix = ""
+    }
+
+    status   = "Enabled"
+    priority = 1
+    destination {
+      bucket = module.cp_compliance_bucket.secure_bucket.arn
+    }
+    delete_marker_replication {
+      status = "Disabled"
+    }
+  }
+}

--- a/tools/cust_acct_setup/aws/terraform.tfvars.sample
+++ b/tools/cust_acct_setup/aws/terraform.tfvars.sample
@@ -1,0 +1,21 @@
+account_id = "<existing AWS Account Number>"
+region = "<AWS region to put resources in>"
+
+# To use a user/secret/access for the credential
+create_iamuser = true
+create_rolearn = false
+username = "<IAM User to create - defaults to codepipes-user>"
+
+# To use a role ARN for the credential
+create_iamuser = false
+create_rolearn = true
+rolename = "<name for IAM role - defaults to codepipes-role>"
+codepipes_org_id = "<Organization ID in Code Pipes to associate with this role>"
+codepipes_aws_account = "<Code Pipes AWS Account # to use - defaults to Code Pipes Production>"
+codepipes_aws_account_user = "<username in codepipes_aws_account that Code Pipes is using - defaults to root>"
+
+# optional (i.e. these have defaults)
+bucket_name_prefix = "<unique prefix for S3 buckets>"
+code_build_queue_name = "<unique name for Code Build status queue"
+key_name = "<name for KMS key to create>"
+code_build_topic_name = "<Code Build topic name>"

--- a/tools/cust_acct_setup/aws/variables.tf
+++ b/tools/cust_acct_setup/aws/variables.tf
@@ -1,0 +1,86 @@
+variable "region" {
+  description = "The name of the AWS region to use"
+  type        = string
+}
+
+variable "account_id" {
+  description = "The AWS Account number where the resources are to be created"
+  type        = string
+}
+variable "username" {
+  description = "The name of the IAM user to create"
+  type        = string
+  default     = "codepipes-user"
+}
+
+variable "rolename" {
+  description = "The name of the IAM role to create"
+  type        = string
+  default     = "codepipes_role"
+}
+
+variable "codepipes_org_id" {
+  description = "Code Pipes Organization ID to be used during role ARN creation"
+  type        = string
+  default     = ""
+}
+
+variable "create_rolearn" {
+  description = "Use AWS Role ARN as Code Pipes credential"
+  type        = bool
+  default     = false
+}
+
+variable "create_iamuser" {
+  description = "Use AWS IAM user as Code Pipes credential"
+  type        = bool
+  default     = true
+}
+
+variable "bucket_name_prefix" {
+  description = "The prefix to use for names of the S3 buckets to be used for storing Code Pipes pipeline artifacts"
+  type        = string
+  default     = "codepipes"
+}
+
+variable "key_name" {
+  description = "The KMS key name to create"
+  type        = string
+  default     = "codepipes_kms_key"
+}
+
+variable "code_build_topic_name" {
+  description = "The SNS topic name for Code Build"
+  type        = string
+  default     = "code-builds"
+}
+
+variable "code_build_queue_name" {
+  description = "The SQS queue name for Code Build"
+  type        = string
+  default     = "codepipes-events"
+}
+
+variable "sqs_queue_retention_period" {
+  description = "The SQS queue message retention period in seconds"
+  type        = number
+  default     = 172800 # 2 days
+}
+
+variable "sqs_queue_receive_wait_time" {
+  description = "The SQS queue receive wait time in seconds"
+  type        = number
+  default     = 20
+}
+
+variable "codepipes_aws_account" {
+  description = "AWS account used for Role ARN creation"
+  type        = string
+  default     = "303665096113"
+}
+
+variable "codepipes_aws_account_user" {
+  description = "AWS IAM user in codepipes_aws_account used by Code Pipes"
+  type        = string
+  default     = "root"
+}

--- a/tools/cust_acct_setup/azure/README.md
+++ b/tools/cust_acct_setup/azure/README.md
@@ -1,0 +1,57 @@
+## To create Code Pipes resources in an Azure subscription
+
+Prerequisites:
+- Azure subscription has been created
+- Azure authentication setup locally using an account that has necessary permissions on the subscription. This can be done using the Azure CLI - "az login".
+
+Execution:
+1. Run terraform init
+```
+$ terraform init
+Initializing the backend...
+
+Initializing provider plugins...
+- Finding latest version of hashicorp/azuread...
+- Finding hashicorp/azurerm versions matching "~> 3.0.0"...
+- Installing hashicorp/azuread v2.30.0...
+- Installed hashicorp/azuread v2.30.0 (signed by HashiCorp)
+- Installing hashicorp/azurerm v3.0.2...
+- Installed hashicorp/azurerm v3.0.2 (signed by HashiCorp)
+
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+<snip>
+```
+
+2. Create terraform.tfvars file
+```
+$ cp terraform.tfvars.sample terraform.tfvars
+
+# use your editor of choice to adjust the values as appropriate
+```
+
+3. Run terraform apply
+```
+$ terraform apply
+
+Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
+  + create
+  <snip>
+Do you want to perform these actions?
+  Terraform will perform the actions described above.
+  Only 'yes' will be accepted to approve.
+
+  Enter a value: yes
+```
+
+4. Retrieve service principal password
+
+```
+$ cat terraform.tfstate|jq -r '.outputs["codepipes_service_principal_pwd"].value'
+
+# Note: this requires that 'jq' is installed in the local environment
+```

--- a/tools/cust_acct_setup/azure/main.tf
+++ b/tools/cust_acct_setup/azure/main.tf
@@ -1,0 +1,26 @@
+data "azuread_client_config" "current" {}
+
+resource "azurerm_resource_group" "cp_resource_group" {
+  name     = var.resource_group_name
+  location = var.location
+}
+
+resource "azuread_application" "cp_application" {
+  display_name = var.application_name
+  owners       = [data.azuread_client_config.current.object_id]
+}
+
+resource "azuread_service_principal" "cp_service_principal" {
+  application_id               = azuread_application.cp_application.application_id
+  app_role_assignment_required = false
+  owners                       = [data.azuread_client_config.current.object_id]
+
+  feature_tags {
+    enterprise = true
+    gallery    = true
+  }
+}
+
+resource "azuread_service_principal_password" "cp_service_principal_pwd" {
+  service_principal_id = azuread_service_principal.cp_service_principal.object_id
+}

--- a/tools/cust_acct_setup/azure/outputs.tf
+++ b/tools/cust_acct_setup/azure/outputs.tf
@@ -1,0 +1,28 @@
+output "codepipes_resource_group" {
+  value = azurerm_resource_group.cp_resource_group.id
+}
+
+output "codepipes_client_id" {
+  value = azuread_application.cp_application.application_id
+}
+
+output "codepipes_service_principal_pwd" {
+  value     = azuread_service_principal_password.cp_service_principal_pwd.value
+  sensitive = true
+}
+
+output "codepipes_storage_account" {
+  value = azurerm_storage_account.cp_storage_account.id
+}
+
+output "codepipes_storage_container" {
+  value = azurerm_storage_container.cp_storage_container.resource_manager_id
+}
+
+output "codepipes_servicebus_namespace" {
+  value = azurerm_servicebus_namespace.cp_servicebus_namespace.id
+}
+
+output "codepipes_servicebus_topic" {
+  value = azurerm_servicebus_topic.cp_servicebus_topic.id
+}

--- a/tools/cust_acct_setup/azure/pipeline.tf
+++ b/tools/cust_acct_setup/azure/pipeline.tf
@@ -1,0 +1,132 @@
+data "azurerm_subscription" "primary" {}
+
+resource "azurerm_role_definition" "cp_pipeline_role" {
+  name        = "CodePipesPipelineRole"
+  scope       = data.azurerm_subscription.primary.id
+  description = "Role with permissions required to use Code Pipes"
+
+  permissions {
+    actions = [
+      "Microsoft.Storage/storageAccounts/write",
+      "Microsoft.Storage/storageAccounts/blobServices/containers/delete",
+      "Microsoft.Storage/storageAccounts/blobServices/containers/read",
+      "Microsoft.Storage/storageAccounts/blobServices/containers/write",
+      "Microsoft.Storage/storageAccounts/blobServices/generateUserDelegationKey/action",
+      "Microsoft.ServiceBus/checkNamespaceAvailability/action",
+      "Microsoft.ServiceBus/checkNameAvailability/action",
+      "Microsoft.ServiceBus/register/action",
+      "Microsoft.ServiceBus/unregister/action",
+      "Microsoft.ServiceBus/namespaces/write",
+      "Microsoft.ServiceBus/namespaces/read",
+      "Microsoft.ServiceBus/namespaces/Delete",
+      "Microsoft.ServiceBus/namespaces/authorizationRules/action",
+      "Microsoft.ServiceBus/namespaces/migrate/action",
+      "Microsoft.ServiceBus/namespaces/removeAcsNamepsace/action",
+      "Microsoft.ServiceBus/namespaces/privateEndpointConnectionsApproval/action",
+      "Microsoft.ServiceBus/namespaces/authorizationRules/write",
+      "Microsoft.ServiceBus/namespaces/authorizationRules/read",
+      "Microsoft.ServiceBus/namespaces/authorizationRules/delete",
+      "Microsoft.ServiceBus/namespaces/authorizationRules/listkeys/action",
+      "Microsoft.ServiceBus/namespaces/authorizationRules/regenerateKeys/action",
+      "Microsoft.ServiceBus/namespaces/disasterrecoveryconfigs/checkNameAvailability/action",
+      "Microsoft.ServiceBus/namespaces/disasterRecoveryConfigs/write",
+      "Microsoft.ServiceBus/namespaces/disasterRecoveryConfigs/read",
+      "Microsoft.ServiceBus/namespaces/disasterRecoveryConfigs/delete",
+      "Microsoft.ServiceBus/namespaces/disasterRecoveryConfigs/breakPairing/action",
+      "Microsoft.ServiceBus/namespaces/disasterRecoveryConfigs/failover/action",
+      "Microsoft.ServiceBus/namespaces/disasterRecoveryConfigs/authorizationRules/read",
+      "Microsoft.ServiceBus/namespaces/disasterRecoveryConfigs/authorizationRules/listkeys/action",
+      "Microsoft.ServiceBus/namespaces/eventGridFilters/write",
+      "Microsoft.ServiceBus/namespaces/eventGridFilters/read",
+      "Microsoft.ServiceBus/namespaces/eventGridFilters/delete",
+      "Microsoft.ServiceBus/namespaces/eventhubs/read",
+      "Microsoft.ServiceBus/namespaces/ipFilterRules/read",
+      "Microsoft.ServiceBus/namespaces/ipFilterRules/write",
+      "Microsoft.ServiceBus/namespaces/ipFilterRules/delete",
+      "Microsoft.ServiceBus/namespaces/migrationConfigurations/write",
+      "Microsoft.ServiceBus/namespaces/migrationConfigurations/read",
+      "Microsoft.ServiceBus/namespaces/migrationConfigurations/delete",
+      "Microsoft.ServiceBus/namespaces/migrationConfigurations/revert/action",
+      "Microsoft.ServiceBus/namespaces/migrationConfigurations/upgrade/action",
+      "Microsoft.ServiceBus/namespaces/messagingPlan/read",
+      "Microsoft.ServiceBus/namespaces/messagingPlan/write",
+      "Microsoft.ServiceBus/namespaces/operationresults/read",
+      "Microsoft.ServiceBus/namespaces/skus/read",
+      "Microsoft.ServiceBus/namespaces/providers/Microsoft.Insights/diagnosticSettings/read",
+      "Microsoft.ServiceBus/namespaces/providers/Microsoft.Insights/diagnosticSettings/write",
+      "Microsoft.ServiceBus/namespaces/providers/Microsoft.Insights/logDefinitions/read",
+      "Microsoft.ServiceBus/namespaces/providers/Microsoft.Insights/metricDefinitions/read",
+      "Microsoft.ServiceBus/namespaces/networkruleset/read",
+      "Microsoft.ServiceBus/namespaces/networkruleset/write",
+      "Microsoft.ServiceBus/namespaces/networkruleset/delete",
+      "Microsoft.ServiceBus/namespaces/networkrulesets/read",
+      "Microsoft.ServiceBus/namespaces/networkrulesets/write",
+      "Microsoft.ServiceBus/namespaces/networkrulesets/delete",
+      "Microsoft.ServiceBus/namespaces/privateEndpointConnections/read",
+      "Microsoft.ServiceBus/namespaces/privateEndpointConnections/write",
+      "Microsoft.ServiceBus/namespaces/privateEndpointConnections/delete",
+      "Microsoft.ServiceBus/namespaces/privateEndpointConnections/operationstatus/read",
+      "Microsoft.ServiceBus/namespaces/privateEndpointConnectionProxies/validate/action",
+      "Microsoft.ServiceBus/namespaces/privateEndpointConnectionProxies/read",
+      "Microsoft.ServiceBus/namespaces/privateEndpointConnectionProxies/write",
+      "Microsoft.ServiceBus/namespaces/privateEndpointConnectionProxies/delete",
+      "Microsoft.ServiceBus/namespaces/privateEndpointConnectionProxies/operationstatus/read",
+      "Microsoft.ServiceBus/namespaces/privateLinkResources/read",
+      "Microsoft.ServiceBus/namespaces/queues/write",
+      "Microsoft.ServiceBus/namespaces/queues/read",
+      "Microsoft.ServiceBus/namespaces/queues/Delete",
+      "Microsoft.ServiceBus/namespaces/queues/authorizationRules/action",
+      "Microsoft.ServiceBus/namespaces/queues/authorizationRules/write",
+      "Microsoft.ServiceBus/namespaces/queues/authorizationRules/read",
+      "Microsoft.ServiceBus/namespaces/queues/authorizationRules/delete",
+      "Microsoft.ServiceBus/namespaces/queues/authorizationRules/listkeys/action",
+      "Microsoft.ServiceBus/namespaces/queues/authorizationRules/regenerateKeys/action",
+      "Microsoft.ServiceBus/namespaces/topics/write",
+      "Microsoft.ServiceBus/namespaces/topics/read",
+      "Microsoft.ServiceBus/namespaces/topics/Delete",
+      "Microsoft.ServiceBus/namespaces/topics/authorizationRules/action",
+      "Microsoft.ServiceBus/namespaces/topics/authorizationRules/write",
+      "Microsoft.ServiceBus/namespaces/topics/authorizationRules/read",
+      "Microsoft.ServiceBus/namespaces/topics/authorizationRules/delete",
+      "Microsoft.ServiceBus/namespaces/topics/authorizationRules/listkeys/action",
+      "Microsoft.ServiceBus/namespaces/topics/authorizationRules/regenerateKeys/action",
+      "Microsoft.ServiceBus/namespaces/topics/subscriptions/write",
+      "Microsoft.ServiceBus/namespaces/topics/subscriptions/read",
+      "Microsoft.ServiceBus/namespaces/topics/subscriptions/Delete",
+      "Microsoft.ServiceBus/namespaces/topics/subscriptions/rules/write",
+      "Microsoft.ServiceBus/namespaces/topics/subscriptions/rules/read",
+      "Microsoft.ServiceBus/namespaces/topics/subscriptions/rules/Delete",
+      "Microsoft.ServiceBus/namespaces/virtualNetworkRules/read",
+      "Microsoft.ServiceBus/namespaces/virtualNetworkRules/write",
+      "Microsoft.ServiceBus/namespaces/virtualNetworkRules/delete",
+      "Microsoft.ServiceBus/operations/read",
+      "Microsoft.ServiceBus/locations/deleteVirtualNetworkOrSubnets/action",
+      "Microsoft.ServiceBus/sku/read",
+      "Microsoft.ServiceBus/sku/regions/read",
+      "Microsoft.Resources/subscriptions/resourceGroups/read",
+      "Microsoft.Resources/subscriptions/resourceGroups/write",
+    ]
+    not_actions = []
+    data_actions = [
+      "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read",
+      "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/delete",
+      "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write",
+      "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/add/action",
+      "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/move/action",
+      "Microsoft.ServiceBus/namespaces/messages/send/action",
+      "Microsoft.ServiceBus/namespaces/messages/receive/action",
+    ]
+    not_data_actions = []
+  }
+
+  assignable_scopes = [
+    data.azurerm_subscription.primary.id,
+  ]
+}
+
+resource "azurerm_role_assignment" "cp_pipeline_role_assignment" {
+  #   name               = "00000000-0000-0000-0000-000000000000"
+  scope              = data.azurerm_subscription.primary.id
+  role_definition_id = azurerm_role_definition.cp_pipeline_role.role_definition_resource_id
+  principal_id       = azuread_service_principal.cp_service_principal.object_id
+}

--- a/tools/cust_acct_setup/azure/provider.tf
+++ b/tools/cust_acct_setup/azure/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0.0"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
+provider "azurerm" {
+  features {}
+}

--- a/tools/cust_acct_setup/azure/pubsub.tf
+++ b/tools/cust_acct_setup/azure/pubsub.tf
@@ -1,0 +1,13 @@
+resource "azurerm_servicebus_namespace" "cp_servicebus_namespace" {
+  name                = var.servicebus_namespace
+  location            = azurerm_resource_group.cp_resource_group.location
+  resource_group_name = azurerm_resource_group.cp_resource_group.name
+  sku                 = "Standard"
+}
+
+resource "azurerm_servicebus_topic" "cp_servicebus_topic" {
+  name         = var.servicebus_topic_name
+  namespace_id = azurerm_servicebus_namespace.cp_servicebus_namespace.id
+
+  default_message_ttl = "P1D"
+}

--- a/tools/cust_acct_setup/azure/storage.tf
+++ b/tools/cust_acct_setup/azure/storage.tf
@@ -1,0 +1,16 @@
+resource "azurerm_storage_account" "cp_storage_account" {
+  name                     = var.storage_account_name
+  resource_group_name      = azurerm_resource_group.cp_resource_group.name
+  location                 = azurerm_resource_group.cp_resource_group.location
+  account_kind             = var.storage_account_kind
+  account_tier             = var.storage_account_tier
+  account_replication_type = var.storage_account_replication_type
+  access_tier              = var.storage_account_access_tier
+  min_tls_version          = "TLS1_2"
+}
+
+resource "azurerm_storage_container" "cp_storage_container" {
+  name                  = var.storage_account_container
+  storage_account_name  = azurerm_storage_account.cp_storage_account.name
+  container_access_type = "private"
+}

--- a/tools/cust_acct_setup/azure/terraform.tfvars.sample
+++ b/tools/cust_acct_setup/azure/terraform.tfvars.sample
@@ -1,0 +1,13 @@
+resource_group_name = "<name of resource group to create>"
+location = "<Azure region for resources>"
+application_name = "<name of Azure enterprise application to create>"
+storage_account_name = "<name of Azure storage account to create>"
+storage_account_container = "<name of storage container to create>"
+servicebus_namespace = "<name of Service Bus namespace to create>"
+servicebus_topic_name = "<Service Bus topic to create>"
+
+# optional (i.e. these have defaults)
+storage_account_kind = ""
+storage_account_tier = ""
+storage_account_replication_type = ""
+storage_account_access_tier = ""

--- a/tools/cust_acct_setup/azure/variables.tf
+++ b/tools/cust_acct_setup/azure/variables.tf
@@ -1,0 +1,58 @@
+variable "resource_group_name" {
+  description = "The name of the Azure resource group to create"
+  type        = string
+}
+
+variable "location" {
+  description = "The location of the Azure resources"
+  type        = string
+}
+
+variable "application_name" {
+  description = "The name of the Azure application to create"
+  type        = string
+}
+
+variable "storage_account_name" {
+  description = "The name of the Azure storage account to create for pipeline artifacts"
+  type        = string
+}
+
+variable "storage_account_container" {
+  description = "The name of the BLOB container within the storage account to create"
+  type        = string
+}
+
+variable "storage_account_kind" {
+  description = "The kind of the Azure storage account to create"
+  type        = string
+  default     = "BlobStorage"
+}
+
+variable "storage_account_tier" {
+  description = "The tier of the Azure storage account to create"
+  type        = string
+  default     = "Standard"
+}
+
+variable "storage_account_replication_type" {
+  description = "The replication type for the Azure storage account to create"
+  type        = string
+  default     = "LRS"
+}
+
+variable "storage_account_access_tier" {
+  description = "The access tier of the Azure storage account to create"
+  type        = string
+  default     = "Cool"
+}
+
+variable "servicebus_namespace" {
+  description = "The name of the Azure service bus namespace"
+  type        = string
+}
+
+variable "servicebus_topic_name" {
+  description = "The name for the Azure service bus topic"
+  type        = string
+}

--- a/tools/cust_acct_setup/gcp/README.md
+++ b/tools/cust_acct_setup/gcp/README.md
@@ -1,0 +1,72 @@
+## To create Code Pipes resources in a GCP project
+
+Prerequisites:
+- GCP project has been created
+- GCP authentication setup locally using an account that has necessary permissions (usually at least Project Editor) on the project. Typically you would use "gcloud auth application-default login"
+
+Execution:
+1. Run terraform init
+```
+$ terraform init
+
+Initializing the backend...
+
+Initializing provider plugins...
+- Finding latest version of hashicorp/google...
+- Installing hashicorp/google v4.44.1...
+- Installed hashicorp/google v4.44.1 (signed by HashiCorp)
+
+Terraform has created a lock file .terraform.lock.hcl to record the provider
+selections it made above. Include this file in your version control repository
+so that Terraform can guarantee to make the same selections by default when
+you run "terraform init" in the future.
+
+Terraform has been successfully initialized!
+<snip>
+```
+
+2. Create terraform.tfvars file
+```
+$ cp terraform.tfvars.sample terraform.tfvars
+
+# use your editor of choice to adjust the values as appropriate
+```
+
+3. Run terraform apply
+```
+$ terraform apply
+
+Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
+  + create
+  <snip>
+Do you want to perform these actions?
+  Terraform will perform the actions described above.
+  Only 'yes' will be accepted to approve.
+
+  Enter a value: yes
+```
+
+If you see an error that looks like this:
+```
+ Error: Error creating KeyRing: googleapi: Error 409: KeyRing projects/doug-test-cust/locations/global/keyRings/codepipes-keys already exists.
+ 
+   with google_kms_key_ring.cp_key_ring,
+   on kms.tf line 1, in resource "google_kms_key_ring" "cp_key_ring":
+    1: resource "google_kms_key_ring" "cp_key_ring" {
+```
+
+It means that the keyring specified in terraform.tfvars already exists. GCP doesn't currently allow keyrings to be deleted so either a new name needs to be chosen, or you can import the existing keyring into the state:
+
+```
+$ terraform import google_kms_key_ring.cp_key_ring projects/<project ID>/locations/global/keyRings/<key ring name>
+
+# Then run terraform apply again
+```
+
+4. Download the Service account key file
+
+```
+$ cat terraform.tfstate|jq -r '.outputs["codepipes_service_account_key"].value'|base64 -d > service-account.json
+
+# Note: this requires that 'jq' and 'base64' are installed in the local environment
+```

--- a/tools/cust_acct_setup/gcp/cloudrun.tf
+++ b/tools/cust_acct_setup/gcp/cloudrun.tf
@@ -1,0 +1,41 @@
+resource "google_project_service" "cloudrun_apis" {
+  project  = data.google_project.project.name
+  for_each = var.with_cloudrun ? toset(var.cloudrun_services) : []
+  service  = each.value
+  disable_on_destroy = false
+}
+
+resource "google_project_iam_custom_role" "cp_cloudrun_role" {
+  count       = var.with_cloudrun ? 1 : 0
+  project     = data.google_project.project.name
+  role_id     = "CodePipesCloudRunRole"
+  title       = "Code Pipes CloudRun Permissions"
+  description = "Role required for cloudrun service for Code Pipes."
+  permissions = [
+    "serviceusage.services.use",
+    "secretmanager.versions.list",
+    "secretmanager.secrets.create",
+    "secretmanager.secrets.delete",
+    "secretmanager.versions.add",
+    "secretmanager.versions.access",
+    "run.revisions.delete",
+    "run.revisions.get",
+    "run.revisions.list",
+    "run.routes.get",
+    "run.routes.list",
+    "run.services.create",
+    "run.services.delete",
+    "run.services.get",
+    "run.services.getIamPolicy",
+    "run.services.list",
+    "run.services.setIamPolicy",
+    "run.services.update"
+  ]
+}
+
+resource "google_project_iam_binding" "cloudrun_role_assignment" {
+  count   = var.with_cloudrun ? 1 : 0
+  project = data.google_project.project.name
+  role    = google_project_iam_custom_role.cp_cloudrun_role[0].id
+  members = ["serviceAccount:${google_service_account.cp_service_acct.email}"]
+}

--- a/tools/cust_acct_setup/gcp/gke.tf
+++ b/tools/cust_acct_setup/gcp/gke.tf
@@ -1,0 +1,13 @@
+resource "google_project_service" "gke_apis" {
+  project  = data.google_project.project.name
+  for_each = var.with_gke ? toset(var.gke_services) : []
+  service  = each.value
+  disable_on_destroy = false
+}
+
+resource "google_project_iam_binding" "gke_role_assignment" {
+  count   = var.with_gke ? 1 : 0
+  project = data.google_project.project.name
+  role    = "roles/container.admin"
+  members = ["serviceAccount:${google_service_account.cp_service_acct.email}"]
+}

--- a/tools/cust_acct_setup/gcp/kms.tf
+++ b/tools/cust_acct_setup/gcp/kms.tf
@@ -1,0 +1,6 @@
+resource "google_kms_key_ring" "cp_key_ring" {
+  name     = var.key_ring
+  location = "global"
+  project  = var.project
+}
+  

--- a/tools/cust_acct_setup/gcp/main.tf
+++ b/tools/cust_acct_setup/gcp/main.tf
@@ -1,0 +1,20 @@
+data "google_project" "project" {
+  project_id = var.project
+}
+
+resource "google_project_service" "apis" {
+  project  = data.google_project.project.name
+  for_each = toset(var.api_services)
+  service  = each.value
+  disable_on_destroy = false
+}
+
+resource "google_service_account" "cp_service_acct" {
+  project      = data.google_project.project.name
+  account_id   = var.service_account_name
+  display_name = "Code Pipes Service Account"
+}
+
+resource "google_service_account_key" "cp_service_acct_key" {
+  service_account_id = google_service_account.cp_service_acct.name
+}

--- a/tools/cust_acct_setup/gcp/outputs.tf
+++ b/tools/cust_acct_setup/gcp/outputs.tf
@@ -1,0 +1,28 @@
+output "codepipes_service_account_id" {
+  value = google_service_account.cp_service_acct.account_id
+}
+
+output "codepipes_service_account_email" {
+  value = google_service_account.cp_service_acct.email
+}
+
+output "codepipes_artifact_bucket" {
+  value = google_storage_bucket.cp_artifact_bucket.name
+}
+
+output "codepipes_key_ring" {
+  value = google_kms_key_ring.cp_key_ring.id
+}
+
+output "codepipes_cloud_build_topic" {
+  value = google_pubsub_topic.codepipes-cloud-build-topic.id
+}
+
+output "codepipes_cloud_build_listener" {
+  value = google_pubsub_subscription.codepipes-cloud-build-listener.id
+}
+
+output "codepipes_service_account_key" {
+  value = google_service_account_key.cp_service_acct_key.private_key
+  sensitive = true
+}

--- a/tools/cust_acct_setup/gcp/pipeline.tf
+++ b/tools/cust_acct_setup/gcp/pipeline.tf
@@ -1,0 +1,87 @@
+resource "google_project_iam_custom_role" "cp_pipeline_role" {
+  project     = data.google_project.project.name
+  role_id     = "CodePipesPipelineRole"
+  title       = "Code Pipes Permissions to use resources"
+  description = "Role required to use Code Pipes"
+  permissions = [
+    "cloudbuild.builds.create",
+    "cloudbuild.builds.get",
+    "cloudbuild.builds.list",
+    "cloudkms.cryptoKeys.create",
+    "cloudkms.cryptoKeys.get",
+    "cloudkms.cryptoKeys.update",
+    "cloudkms.cryptoKeyVersions.create",
+    "cloudkms.cryptoKeyVersions.get",
+    "cloudkms.cryptoKeyVersions.list",
+    "cloudkms.cryptoKeyVersions.useToEncrypt",
+    "cloudkms.keyRings.get",
+    "iam.serviceAccounts.actAs",
+    "pubsub.snapshots.list",
+    "pubsub.subscriptions.consume",
+    "pubsub.subscriptions.list",
+    "pubsub.topics.list",
+    "resourcemanager.projects.get",
+    "resourcemanager.projects.getIamPolicy",
+    "run.services.get",
+    "run.services.update",
+    "storage.buckets.get",
+    "storage.buckets.list",
+    "storage.objects.get",
+    "storage.objects.list",
+    "storage.objects.create",
+    "storage.objects.delete",
+    "serviceusage.services.use",
+    "secretmanager.versions.list",
+    "secretmanager.secrets.create",
+    "secretmanager.secrets.delete",
+    "secretmanager.versions.add",
+    "secretmanager.versions.access",
+    # things we should move to createRole
+    "storage.buckets.create",
+    "pubsub.topics.create",
+    "pubsub.subscriptions.create",
+  ]
+}
+
+resource "google_project_iam_custom_role" "cp_pipeline_creator_role" {
+  project     = data.google_project.project.name
+  role_id     = "CodePipesResourceCreatorRole"
+  title       = "Code Pipes Permissions to create resources"
+  description = "Role required to create Code Pipes resources"
+  permissions = [
+    "cloudkms.keyRings.create",
+    "pubsub.subscriptions.create",
+    "pubsub.topics.attachSubscription",
+    "pubsub.topics.create",
+    "resourcemanager.projects.setIamPolicy",
+    "run.services.create",
+    "run.services.delete",
+    "storage.buckets.create",
+    "storage.buckets.delete",
+  ]
+}
+
+resource "google_project_iam_binding" "pipeline_role_assignment" {
+  project = data.google_project.project.name
+  role    = google_project_iam_custom_role.cp_pipeline_role.id
+  members = ["serviceAccount:${google_service_account.cp_service_acct.email}"]
+}
+
+# resource "google_project_iam_custom_role" "cp_cloudbuild_role" {
+#   project     = data.google_project.project.name
+#   role_id     = "CodePipesCloudBuildRole"
+#   title       = "Code Pipes CloudBuild Permissions"
+#   description = "Role required by default cloudbuild service account to use Code Pipes."
+#   permissions = [
+#     "cloudkms.cryptoKeyVersions.useToDecrypt",
+#     "cloudkms.locations.get",
+#     "cloudkms.locations.list",
+#     "resourcemanager.projects.get"
+#   ]
+# }
+
+resource "google_project_iam_member" "cloudbuild_role_assignment" {
+  project = data.google_project.project.name
+  role    = "roles/cloudkms.cryptoKeyDecrypter"
+  member  = "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
+}

--- a/tools/cust_acct_setup/gcp/pubsub.tf
+++ b/tools/cust_acct_setup/gcp/pubsub.tf
@@ -1,0 +1,21 @@
+resource "google_pubsub_topic" "codepipes-cloud-build-topic" {
+  name    = var.cloud_build_topic_name
+  project = var.project
+}
+
+resource "google_pubsub_subscription" "codepipes-cloud-build-listener" {
+  name    = var.cloud_build_subscription_name
+  topic   = google_pubsub_topic.codepipes-cloud-build-topic.name
+  project = var.project
+
+  message_retention_duration = "172800s"
+  ack_deadline_seconds       = 10
+
+  expiration_policy {
+    ttl = "604800s"
+  }
+  retry_policy {
+    minimum_backoff = "10s"
+    maximum_backoff = "600s"
+  }
+}

--- a/tools/cust_acct_setup/gcp/storage.tf
+++ b/tools/cust_acct_setup/gcp/storage.tf
@@ -1,0 +1,6 @@
+resource "google_storage_bucket" "cp_artifact_bucket" {
+  name     = var.bucket_name
+  location = var.bucket_region
+
+  project = var.project
+}

--- a/tools/cust_acct_setup/gcp/terraform.tfvars.sample
+++ b/tools/cust_acct_setup/gcp/terraform.tfvars.sample
@@ -1,0 +1,15 @@
+project = "<existing GCP project name>"
+service_account_name = "<name of service account to create"
+bucket_name = "<name for GCS bucket>"
+
+# optional (i.e. these have defaults)
+bucket_region = "<GCP region for the bucket>"
+key_ring = "<KMS key ring name>"
+cloud_build_topic_name = "<name for Cloud Build topic>"
+cloud_build_subscription_name = "<name for Cloud Build subscription>"
+
+# to configure cloudrun
+with_cloudrun = true | false
+
+# to configure GKE
+with_gke = true | false

--- a/tools/cust_acct_setup/gcp/variables.tf
+++ b/tools/cust_acct_setup/gcp/variables.tf
@@ -1,0 +1,78 @@
+variable "project" {
+  description = "The ID of the project to configure."
+  type        = string
+}
+
+variable "service_account_name" {
+  description = "The name of the target GCP service account to create"
+  type        = string
+}
+
+variable "bucket_name" {
+  description = "The name of the GCS bucket to be used for storing Code Pipes pipeline artifacts"
+  type        = string
+}
+
+variable "bucket_region" {
+  description = "The GCP region where the bucket should be stored"
+  type        = string
+  default     = "US"
+}
+
+variable "key_ring" {
+  description = "The KMS key ring to be used"
+  type        = string
+  default     = "codepipes-keys"
+}
+
+variable "cloud_build_topic_name" {
+  description = "The Pub/Sub topic name for Cloud Build"
+  type        = string
+  default     = "cloud-builds"
+}
+
+variable "cloud_build_subscription_name" {
+  description = "The name of the subscription for the Cloud Build listener"
+  type = string
+  default = "codepipes.events.pipeline-listener" 
+}
+
+variable "with_gke" {
+  description = "Configure GKE services for project"
+  type        = bool
+  default     = false
+}
+
+variable "with_cloudrun" {
+  description = "Configure CloudRun services for project"
+  type        = bool
+  default     = false
+}
+
+# These are really constants - just wanted them centrally defined
+variable "api_services" {
+  type = list(string)
+  default = [
+    "compute.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "cloudbuild.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
+    "cloudkms.googleapis.com",
+    "pubsub.googleapis.com",
+  ]
+}
+
+variable "cloudrun_services" {
+  type = list(string)
+  default = [
+    "secretmanager.googleapis.com",
+    "run.googleapis.com"
+  ]
+}
+
+variable "gke_services" {
+  type = list(string)
+  default = [
+    "container.googleapis.com"
+  ]
+}


### PR DESCRIPTION
Added TF scripts for AWS, GCP and Azure that will create the required
resources within a given customer's account/project/subscription.
The resulting tfstate file can then be uploaded via the credential
creation process to associate the created resources with the new
CP cloud credential.

There is a README with for each cloud which explains how to use and
and cloud specific nuances.
