### PR TITLE
VAN-3280 Fix typo in Borat landing page

### DIFF
--- a/dependency-demo/borat-gcs-redis/readme.md
+++ b/dependency-demo/borat-gcs-redis/readme.md
@@ -10,3 +10,18 @@ Folder structure:
 - `src` - contains the app source code along with dependencies
 - `infra` - contains the base infrastructure for the application
 - `codepipes-bundle` - contains bundle yaml files that be used to setup demo on codepipes.
+
+####To run locally:
+
+There is a docker-compose.yml file which can be used to build and run the app:
+
+$ docker compose -f docker-compose.yml build
+
+To run it, you need to set 2 environnment variables and be signed into GCP with
+application-default credentials.
+
+$ export BUCKET_NAME=<name of some existing bucket that you have write access to>
+$ export GCP_PROJECT=<name of GCP project where bucket is>
+$ docker compose -f docker-compose.yml up -d
+
+You can then use your browser at localhost:8080 and the Borat image should come up.

--- a/dependency-demo/borat-gcs-redis/src/docker-compose.yml
+++ b/dependency-demo/borat-gcs-redis/src/docker-compose.yml
@@ -1,0 +1,47 @@
+version: "3.5"
+
+networks:
+  borat-network:
+    driver: bridge
+    name: borat-network
+
+volumes:
+  borat_redis_data:
+    name: borat_redis_data
+
+services:
+  redis:
+    container_name: redis
+    image: redis
+    networks: [ borat-network ]
+    command:
+      [
+        "redis-server",
+        "--port",
+        "6379",
+        "--save",
+        "10",
+        "1",
+        "--loglevel",
+        "warning"
+      ]
+    ports:
+      - "6379:6379"
+    volumes:
+      - borat_redis_data:/data
+  borat:
+    build: .
+    container_name: borat-redis
+    image: borat-redis
+    networks: [ borat-network ]
+    ports:
+      - "8080:8080"
+    environment:
+      BUCKET_NAME: ${BUCKET_NAME}
+      PROJECT_ID: ${GCP_PROJECT}
+      IMAGE_PATH: test.gif
+      REDISHOST: redis
+      REDISPORT: 6379
+      GOOGLE_APPLICATION_CREDENTIALS: /config/application_default_credentials.json
+    volumes:
+      - ~/.config/gcloud/:/config

--- a/dependency-demo/borat-gcs-redis/src/main.go
+++ b/dependency-demo/borat-gcs-redis/src/main.go
@@ -76,7 +76,7 @@ func main() {
 		// Render index template
 		return c.Render("index", fiber.Map{
 			"path":        "/gif",
-			"vistorCount": vc,
+			"visitorCount": vc,
 		})
 	})
 	app.Get("/gif", getStorageFile)

--- a/dependency-demo/borat-gcs-redis/src/views/index.html
+++ b/dependency-demo/borat-gcs-redis/src/views/index.html
@@ -171,7 +171,7 @@
     <div class=container>
         <div class=header>
             <h1>Congratulations!</h1>
-            <h2>Vistor Number {{.vistorCount}}</h2>
+            <h2>Visitor Number {{.visitorCount}}</h2>
             <p>If you have reached here everything went well<br>
                 What happened:<br>
                 1. GCS bucket has been created and a borat gif has been uploaded with terraform<br>


### PR DESCRIPTION
The word visitor was misspelled in the index.html.

Also added a docker-compose.yml file so that one can run the app
locally for testing.
