### PR TITLE
VAN-3608 Fix GCP project issue in setup script

### DIFF
--- a/tools/cust_acct_setup/gcp/cloudrun.tf
+++ b/tools/cust_acct_setup/gcp/cloudrun.tf
@@ -1,5 +1,5 @@
 resource "google_project_service" "cloudrun_apis" {
-  project  = data.google_project.project.name
+  project  = data.google_project.project.project_id
   for_each = var.with_cloudrun ? toset(var.cloudrun_services) : []
   service  = each.value
   disable_on_destroy = false
@@ -7,7 +7,7 @@ resource "google_project_service" "cloudrun_apis" {
 
 resource "google_project_iam_custom_role" "cp_cloudrun_role" {
   count       = var.with_cloudrun ? 1 : 0
-  project     = data.google_project.project.name
+  project     = data.google_project.project.project_id
   role_id     = var.iam_cloudrun_role_name
   title       = "Code Pipes CloudRun Permissions"
   description = "Role required for cloudrun service for Code Pipes."
@@ -35,7 +35,7 @@ resource "google_project_iam_custom_role" "cp_cloudrun_role" {
 
 resource "google_project_iam_binding" "cloudrun_role_assignment" {
   count   = var.with_cloudrun ? 1 : 0
-  project = data.google_project.project.name
+  project = data.google_project.project.project_id
   role    = google_project_iam_custom_role.cp_cloudrun_role[0].id
   members = ["serviceAccount:${google_service_account.cp_service_acct.email}"]
 }

--- a/tools/cust_acct_setup/gcp/gke.tf
+++ b/tools/cust_acct_setup/gcp/gke.tf
@@ -1,5 +1,5 @@
 resource "google_project_service" "gke_apis" {
-  project  = data.google_project.project.name
+  project  = data.google_project.project.project_id
   for_each = var.with_gke ? toset(var.gke_services) : []
   service  = each.value
   disable_on_destroy = false
@@ -7,7 +7,7 @@ resource "google_project_service" "gke_apis" {
 
 resource "google_project_iam_binding" "gke_role_assignment" {
   count   = var.with_gke ? 1 : 0
-  project = data.google_project.project.name
+  project = data.google_project.project.project_id
   role    = "roles/container.admin"
   members = ["serviceAccount:${google_service_account.cp_service_acct.email}"]
 }

--- a/tools/cust_acct_setup/gcp/kms.tf
+++ b/tools/cust_acct_setup/gcp/kms.tf
@@ -1,6 +1,6 @@
 resource "google_kms_key_ring" "cp_key_ring" {
   name     = var.key_ring
   location = "global"
-  project  = var.project
+  project  = data.google_project.project.project_id
 }
   

--- a/tools/cust_acct_setup/gcp/main.tf
+++ b/tools/cust_acct_setup/gcp/main.tf
@@ -3,14 +3,14 @@ data "google_project" "project" {
 }
 
 resource "google_project_service" "apis" {
-  project  = data.google_project.project.name
+  project  = data.google_project.project.project_id
   for_each = toset(var.api_services)
   service  = each.value
   disable_on_destroy = false
 }
 
 resource "google_service_account" "cp_service_acct" {
-  project      = data.google_project.project.name
+  project      = data.google_project.project.project_id
   account_id   = var.service_account_name
   display_name = "Code Pipes Service Account"
 }

--- a/tools/cust_acct_setup/gcp/pipeline.tf
+++ b/tools/cust_acct_setup/gcp/pipeline.tf
@@ -1,5 +1,5 @@
 resource "google_project_iam_custom_role" "cp_pipeline_role" {
-  project     = data.google_project.project.name
+  project     = data.google_project.project.project_id
   role_id     = var.iam_pipeline_role_name
   title       = "Code Pipes Permissions to use resources"
   description = "Role required to use Code Pipes"
@@ -44,7 +44,7 @@ resource "google_project_iam_custom_role" "cp_pipeline_role" {
 }
 
 resource "google_project_iam_custom_role" "cp_pipeline_creator_role" {
-  project     = data.google_project.project.name
+  project     = data.google_project.project.project_id
   role_id     = var.iam_creator_role_name
   title       = "Code Pipes Permissions to create resources"
   description = "Role required to create Code Pipes resources"
@@ -62,13 +62,13 @@ resource "google_project_iam_custom_role" "cp_pipeline_creator_role" {
 }
 
 resource "google_project_iam_binding" "pipeline_role_assignment" {
-  project = data.google_project.project.name
+  project = data.google_project.project.project_id
   role    = google_project_iam_custom_role.cp_pipeline_role.id
   members = ["serviceAccount:${google_service_account.cp_service_acct.email}"]
 }
 
 resource "google_project_iam_member" "cloudbuild_role_assignment" {
-  project = data.google_project.project.name
+  project = data.google_project.project.project_id
   role    = "roles/cloudkms.cryptoKeyDecrypter"
   member  = "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
 }

--- a/tools/cust_acct_setup/gcp/pubsub.tf
+++ b/tools/cust_acct_setup/gcp/pubsub.tf
@@ -1,12 +1,12 @@
 resource "google_pubsub_topic" "codepipes-cloud-build-topic" {
   name    = var.cloud_build_topic_name
-  project = var.project
+  project = data.google_project.project.project_id
 }
 
 resource "google_pubsub_subscription" "codepipes-cloud-build-listener" {
   name    = var.cloud_build_subscription_name
   topic   = google_pubsub_topic.codepipes-cloud-build-topic.name
-  project = var.project
+  project = data.google_project.project.project_id
 
   message_retention_duration = "172800s"
   ack_deadline_seconds       = 10


### PR DESCRIPTION
The cust_acct_setup TF code was using project.name instead of
project.project_id to refer to a GCP project. This causes issues
if the project name and id are different (e.g. vanguard-dev)
