### PR TITLE
VAN-3675 Add pubsub.subscription.update perm

### DIFF
--- a/tools/cust_acct_setup/gcp/pipeline.tf
+++ b/tools/cust_acct_setup/gcp/pipeline.tf
@@ -51,6 +51,7 @@ resource "google_project_iam_custom_role" "cp_pipeline_creator_role" {
   permissions = [
     "cloudkms.keyRings.create",
     "pubsub.subscriptions.create",
+    "pubsub.subscriptions.update",
     "pubsub.topics.attachSubscription",
     "pubsub.topics.create",
     "resourcemanager.projects.setIamPolicy",


### PR DESCRIPTION
For GCP, the role for creating resources needs the subscription
update permission.
