### PR TITLE
VAN-3817 update App runner instance permissions to allow secret manager

### DIFF
--- a/serverless-sample/infra/aws/instance_iam.tf
+++ b/serverless-sample/infra/aws/instance_iam.tf
@@ -42,6 +42,16 @@ resource "aws_iam_policy" "instance_policy" {
       "Effect": "Allow",
       "Action": "s3:*",
       "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "elasticache:*",
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "secretsmanager:*",
+      "Resource": "*"
     }
   ]
 }

--- a/tfs/aws-ecr-apprunner/instance_iam.tf
+++ b/tfs/aws-ecr-apprunner/instance_iam.tf
@@ -47,6 +47,11 @@ resource "aws_iam_policy" "instance_policy" {
       "Effect": "Allow",
       "Action": "elasticache:*",
       "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": "secretsmanager:*",
+      "Resource": "*"
     }
   ]
 }


### PR DESCRIPTION
Add permission to AWS App runner instance to access secret manager 