### PR TITLE
VAN-4049 fix private repo reference

### DIFF
--- a/voting/bundle/aws/eks/env.yml
+++ b/voting/bundle/aws/eks/env.yml
@@ -5,9 +5,9 @@ environment:
   description: Voting app infra on AWS
   revision:
     driver: github
-    repo: https://github.com/cldcvr/vanguard-demo
+    repo: https://github.com/cldcvr/codepipes-tutorials
     dir: voting/infra/aws/eks
-    identifier: master
+    identifier: main
     type: branch
   variables:
     - type: tf_var

--- a/voting/bundle/aws/eks_https/env.yml
+++ b/voting/bundle/aws/eks_https/env.yml
@@ -5,9 +5,9 @@ environment:
   description: Voting app infra on AWS
   revision:
     driver: github
-    repo: https://github.com/cldcvr/vanguard-demo
+    repo: https://github.com/cldcvr/codepipes-tutorials
     dir: voting/infra/aws/eks
-    identifier: master
+    identifier: main
     type: branch
   variables:
     - type: tf_var


### PR DESCRIPTION
codepipes-tutorial being a public repository must not refer resources in vanguard-demo (private repo) since it’ll end up being a broken reference for any user.