### PR TITLE
VAN-4147 Remove use of ACL to set AWS bucket private

### DIFF
--- a/tools/cust_acct_setup/aws/modules/s3/main.tf
+++ b/tools/cust_acct_setup/aws/modules/s3/main.tf
@@ -3,11 +3,6 @@ resource "aws_s3_bucket" "secure_bucket" {
   force_destroy = true
 }
 
-resource "aws_s3_bucket_acl" "secure_bucket_acl" {
-  bucket = aws_s3_bucket.secure_bucket.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_versioning" "secure_bucket_versioning" {
   bucket = aws_s3_bucket.secure_bucket.id
   versioning_configuration {


### PR DESCRIPTION
AWS now defaults buckets to be private and disables ACL use so we
no longer need to set this.
