### PR TITLE
VAN-4317 Add secretmgr to list to enable

### DIFF
--- a/tools/cust_acct_setup/gcp/variables.tf
+++ b/tools/cust_acct_setup/gcp/variables.tf
@@ -77,6 +77,7 @@ variable "api_services" {
     "cloudresourcemanager.googleapis.com",
     "cloudkms.googleapis.com",
     "pubsub.googleapis.com",
+    "secretmanager.googleapis.com"
   ]
 }
 


### PR DESCRIPTION
We need to have GCP secret manager enabled for customer accounts used
by Code Pipes. This enables it during cust_acct_setup.
